### PR TITLE
Fix closing comment in BatchedMerkleTree module

### DIFF
--- a/BatchedMerkleTree/src/BatchedMerkleTree.jl
+++ b/BatchedMerkleTree/src/BatchedMerkleTree.jl
@@ -182,4 +182,4 @@ function verify(root::MerkleRoot, batched_proof::BatchedMerkleProof; depth, leav
     return layer[1] == root.root
 end
 
-end # module MerkleTree
+end # module BatchedMerkleTree


### PR DESCRIPTION
## Summary
- update module closing comment in `BatchedMerkleTree.jl` to match actual module name

## Testing
- `git status --short`
