### PR TITLE
Add negative Merkle proof tests

### DIFF
--- a/BatchedMerkleTree/src/BatchedMerkleTree.jl
+++ b/BatchedMerkleTree/src/BatchedMerkleTree.jl
@@ -182,4 +182,4 @@ function verify(root::MerkleRoot, batched_proof::BatchedMerkleProof; depth, leav
     return layer[1] == root.root
 end
 
-end # module MerkleTree
+end # module BatchedMerkleTree

--- a/BatchedMerkleTree/test/merkletree_test.jl
+++ b/BatchedMerkleTree/test/merkletree_test.jl
@@ -22,4 +22,14 @@ end
     root = get_root(tree)
 
     @test verify(root, proof; depth, leaves=queried_leaves, leaf_indices=queries)
+
+    # Tamper with one of the queried leaves and ensure verification fails
+    corrupted_leaves = copy(queried_leaves)
+    corrupted_leaves[1] = rand(UInt16, K)
+    @test !verify(root, proof; depth, leaves=corrupted_leaves, leaf_indices=queries)
+
+    # Tamper with the proof itself and ensure verification fails
+    corrupted_proof = BatchedMerkleProof(copy(proof.proof))
+    corrupted_proof.proof[1] = rand(UInt8, length(corrupted_proof.proof[1]))
+    @test !verify(root, corrupted_proof; depth, leaves=queried_leaves, leaf_indices=queries)
 end


### PR DESCRIPTION
## Summary
- extend `merkletree_test.jl` with negative verification cases
- fix closing module comment in `BatchedMerkleTree.jl`

## Testing
- `apt-get update` *(fails: no route to host)*
- `apt-get install -y julia` *(fails: package has no installation candidate)*
- `wget https://julialang-s3.julialang.org/bin/linux/x64/1.9/julia-1.9.0-linux-x86_64.tar.gz` *(fails: no route to host)*
- `julia --project=BatchedMerkleTree -e 'using Pkg; Pkg.test()'` *(fails: command not found)*