### PR TITLE
Fix BinaryPoly256 convert method

### DIFF
--- a/BinaryFields/src/binarypoly.jl
+++ b/BinaryFields/src/binarypoly.jl
@@ -39,7 +39,7 @@ bitsize(::Type{T}) where T <: BinaryPoly = sizeof(T) * 8
 Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{T}) where {T<:BinaryPoly} = T(rand(rng, primitive_type(T)))
 
 Base.convert(::Type{T}, v::U) where {T<:BinaryPoly,U<:BinaryPoly} = T(binary_val(v))
-Base.convert(::Type{BinaryPoly256}, v::NTuple{2, BinaryPoly128}) = T(binary_val.(v))
+Base.convert(::Type{BinaryPoly256}, v::NTuple{2, BinaryPoly128}) = BinaryPoly256(binary_val.(v))
 Base.convert(::Type{T}, x) where T<:BinaryPoly = T(x)
 
 +(a::T, b::T) where {T<:BinaryPoly} = T(binary_val(a) ⊻ binary_val(b))


### PR DESCRIPTION
## Summary
- fix construction of `BinaryPoly256` from two `BinaryPoly128`

## Testing
- `julia --project=test -e 'using Pkg; Pkg.test()'` *(fails: `julia` not found)*
