### PR TITLE
Use registered package names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,16 @@ encodings, and Merkle trees with multiopening proofs.
 
 ## Installation
 
-To use `BinaryFields` or any of the other packages, simply add the package to your Julia environment:
+The packages in this repository are registered in the Julia package registry. To
+use `BinaryFields` or any of the other packages, simply add them by name:
 
 ```julia
 using Pkg
-Pkg.add("https://github.com/bcc-research/CryptoUtilities.jl.git", subdir="BinaryFields")
+Pkg.add("BinaryFields")
 ```
-Replace `subdir="BinaryFields"` with `subdir="BinaryReedSolomon"` or
-`subdir="BatchedMerkleTree"` to install the other packages.
 
-(We are working on adding the packages to the Julia package registry, but for
-now, you can install them directly from the GitHub repository.)
+Replace `"BinaryFields"` with `"BinaryReedSolomon"` or `"BatchedMerkleTree"`
+to install the other packages.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- update installation docs to use registered package names instead of GitHub URLs

## Testing
- `julia --project=BinaryFields -e 'using Pkg; Pkg.test()'` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68af3a9d110083278ad2d60c1b2f45b0